### PR TITLE
Update pipeline version to migrate to Harbor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 def PIPELINE_PARAMETERS = '''
 DESIRED_NODE_NAME = 'docker'
 GIT_CREDENTIALS_ID = 'github'
-PIPELINE_VERSION = 'v2.0.38'
+PIPELINE_VERSION = 'v2.0.47'
 PROJECT_NAME = 'raml-parser-service-e2e-test'
 PLATFORM = 'node'
 TEST_TIMEOUT = '5'


### PR DESCRIPTION
Uses latest Jenkins Pipeline that migrates devdocker to harbor.

https://github.com/mulesoft/automation-jenkins-pipeline/releases/tag/v2.0.47